### PR TITLE
Fix Caddyfile syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ If you are using DNS to verify your domain name, you will also need to configure
       caddy.example.com
       proxy / localhost:8080 {
         transparent
-        tls {
-          dns route53
-        }
+      }
+      tls {
+        dns route53
       }
     env:
       AWS_ACCESS_KEY_ID: AKIA...


### PR DESCRIPTION
tls configuration needs to be on top level of the config file, not below
proxy.

Co-authored-by: Manuel Dewald <m.dewald@sap.com>